### PR TITLE
Revert "compat: Add libprotobuf-cpp-lite-3.9.1-vendorcompat"

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -540,13 +540,6 @@ cc_library_shared {
 }
 
 cc_library_shared {
-    name: "libprotobuf-cpp-lite-3.9.1-vendorcompat",
-    stem: "libprotobuf-cpp-lite-3.9.1",
-    shared_libs: ["libprotobuf-cpp-full-3.9.1-vendorcompat"],
-    vendor: true,
-}
-
-cc_library_shared {
     name: "libui_shim",
     shared_libs: [
         "libui",


### PR DESCRIPTION
 * Ref: https://review.lineageos.org/c/LineageOS/android_hardware_lineage_compat/+/386638
 * Upstream drop this change
 * Cause libprotobuf-cpp-lite-3.9.1-vendorcompat build rule conflicts

This reverts commit ec8aa61d23c96d688a28dbd6451a3537b6a7640e.
