### PR TITLE
compat: Provide libaudioutils shim

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -252,6 +252,17 @@ cc_library_shared {
 }
 
 cc_library_shared {
+    name: "libaudioutils_shim",
+    shared_libs: [
+        "libaudioutils",
+    ],
+    srcs: [
+        "libaudioutils/mutex.cpp",
+    ],
+    vendor: true,
+}
+
+cc_library_shared {
     name: "libavservices_minijail_vendor",
     shared_libs: ["libavservices_minijail"],
     vendor: true,

--- a/libaudioutils/mutex.cpp
+++ b/libaudioutils/mutex.cpp
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: The LineageOS Project
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <audio_utils/mutex.h>
+
+namespace android::audio_utils {
+
+bool mutex_get_enable_flag() {
+    return mutex::kDefaultPriorityInheritance;
+}
+
+}  // namespace android::audio_utils


### PR DESCRIPTION
Code associated with flag mutex_priority_inheritance was removed in https://android.googlesource.com/platform/system/media/+/5575eb736dbadd82e61cc983774718f8334c148d%5E!/#F0.

This shim ensures backwards compatibility.

Change-Id: Id3f2fe268958ae604d5877033da01c8d4ee1b43b